### PR TITLE
added bind_ringbuffer for embedded systems with static memory and added good stuff of othes

### DIFF
--- a/ringbuf.c
+++ b/ringbuf.c
@@ -98,10 +98,11 @@ ringbuf_end(const struct ringbuf_t *rb)
 size_t
 ringbuf_bytes_free(const struct ringbuf_t *rb)
 {
-    if (rb->head >= rb->tail)
-        return ringbuf_capacity(rb) - (rb->head - rb->tail);
+    ssize_t s = rb->head - rb->tail;
+    if (s >= 0)
+        return ringbuf_capacity(rb) - s;
     else
-        return rb->tail - rb->head - 1;
+        return -s - 1;
 }
 
 size_t

--- a/ringbuf.c
+++ b/ringbuf.c
@@ -62,6 +62,8 @@ ringbuf_new(size_t capacity)
 }
 
 /*
+* @brief Bind existing memory to a ringbuffer structure and make it a ringbuffer.
+*
 * This is to bind an existing memory area to a ringbuffer struct for management.
 * This is intended for microcontrollers w/o malloc and with the need for well controlled
 * memory management as the memory is assigned at linking time so we have enough or a linking error.
@@ -69,6 +71,10 @@ ringbuf_new(size_t capacity)
 * areas. So dirty coding can use a dma finished callback and call this routine to bind a ring buffer
 * to the transferred half of the dma memory area but beware of the buffer pointers and threads,
 * know what you code.  
+* @note: This bind assumes that the memory buffer is empty so the pointers are set up to show
+* an empty ring buffer. If you do dirty hacks here, set the pointers for your self after binding
+* the ringbuffer as you should know where the buffer ends and where useful data starts. Just
+* bend ->head and -> tail accordingly. 
 */
 ringbuf_t ringbuf_bind(ringbuf_t ringbuffer, uint8_t *buffer_address) {
 	size_t realcap=0;

--- a/ringbuf.h
+++ b/ringbuf.h
@@ -39,8 +39,7 @@ typedef struct ringbuf_t *ringbuf_t;
  * Returns the new ring buffer object, or 0 if there's not enough
  * memory to fulfill the request for the given capacity.
  */
-ringbuf_t
-ringbuf_new(size_t capacity);
+ringbuf_t ringbufNew(size_t capacity);
 
 /*
  * The size of the internal buffer, in bytes. One or more bytes may be
@@ -67,10 +66,11 @@ ringbuf_new(size_t capacity);
 * the ringbuffer as you should know where the buffer ends and where useful data starts. Just
 * bend ->head and -> tail accordingly. 
 */
-ringbuf_t ringbuf_bind(ringbuf_t ringbuffer, uint8_t *buffer_address);
+ringbuf_t ringbufBind(ringbuf_t ringbuffer, uint8_t *bufferAddress);
  
-size_t
-ringbuf_buffer_size(const struct ringbuf_t *rb);
+ 
+ 
+size_t ringbufBufferSize(const struct ringbuf_t *rb);
 
 /*
  * Deallocate a ring buffer, and, as a side effect, set the pointer to
@@ -83,44 +83,39 @@ ringbuf_free(ringbuf_t *rb);
  * Reset a ring buffer to its initial state (empty).
  */
 void
-ringbuf_reset(ringbuf_t rb);
+ringbufReset(ringbuf_t rb);
 
 /*
  * The usable capacity of the ring buffer, in bytes. Note that this
  * value may be less than the ring buffer's internal buffer size, as
  * returned by ringbuf_buffer_size.
  */
-size_t
-ringbuf_capacity(const struct ringbuf_t *rb);
+size_t ringbufCapacity(const struct ringbuf_t *rb);
 
 /*
  * The number of free/available bytes in the ring buffer. This value
  * is never larger than the ring buffer's usable capacity.
  */
-size_t
-ringbuf_bytes_free(const struct ringbuf_t *rb);
+size_t ringbufBytesFree(const struct ringbuf_t *rb);
 
 /*
  * The number of bytes currently being used in the ring buffer. This
  * value is never larger than the ring buffer's usable capacity.
  */
-size_t
-ringbuf_bytes_used(const struct ringbuf_t *rb);
+size_t ringbufBytesUsed(const struct ringbuf_t *rb);
 
-int
-ringbuf_is_full(const struct ringbuf_t *rb);
 
-int
-ringbuf_is_empty(const struct ringbuf_t *rb);
+int ringbufIsFull(const struct ringbuf_t *rb);
+
+int ringbufIsEmpty(const struct ringbuf_t *rb);
+
 
 /*
  * Const access to the head and tail pointers of the ring buffer.
  */
-const void *
-ringbuf_tail(const struct ringbuf_t *rb);
+const void *ringbufTail(const struct ringbuf_t *rb);
 
-const void *
-ringbuf_head(const struct ringbuf_t *rb);
+const void *ringbufHead(const struct ringbuf_t *rb);
 
 /*
  * Locate the first occurrence of character c (converted to an
@@ -133,8 +128,7 @@ ringbuf_head(const struct ringbuf_t *rb);
  * Note that the offset parameter and the returned offset are logical
  * offsets from the tail pointer, not necessarily linear offsets.
  */
-size_t
-ringbuf_findchr(const struct ringbuf_t *rb, int c, size_t offset);
+size_t ringbufFindchr(const struct ringbuf_t *rb, int c, size_t offset);
 
 /*
  * Beginning at ring buffer dst's head pointer, fill the ring buffer
@@ -155,8 +149,7 @@ ringbuf_findchr(const struct ringbuf_t *rb, int c, size_t offset);
  * Returns the actual number of bytes written to dst: len, if
  * len < ringbuf_buffer_size(dst), else ringbuf_buffer_size(dst).
  */
-size_t
-ringbuf_memset(ringbuf_t dst, int c, size_t len);
+size_t ringbufMemset(ringbuf_t dst, int c, size_t len);
 
 /*
  * Copy n bytes from a contiguous memory area src into the ring buffer
@@ -171,8 +164,7 @@ ringbuf_memset(ringbuf_t dst, int c, size_t len);
  * overflow, the value of the ring buffer's tail pointer may be
  * different than it was before the function was called.
  */
-void *
-ringbuf_memcpy_into(ringbuf_t dst, const void *src, size_t count);
+void *ringbufMemcpyInto(ringbuf_t dst, const void *src, size_t count);
 
 /*
  * This convenience function calls read(2) on the file descriptor fd,
@@ -189,8 +181,7 @@ ringbuf_memcpy_into(ringbuf_t dst, const void *src, size_t count);
  * results in an overflow, the value of the ring buffer's tail pointer
  * may be different than it was before the function was called.
  */
-ssize_t
-ringbuf_read(int fd, ringbuf_t rb, size_t count);
+ssize_t ringbufRead(int fd, ringbuf_t rb, size_t count);
 
 /*
  * Copy n bytes from the ring buffer src, starting from its tail
@@ -207,8 +198,8 @@ ringbuf_read(int fd, ringbuf_t rb, size_t count);
  * count is greater than the number of bytes used in the ring buffer,
  * no bytes are copied, and the function will return 0.
  */
-void *
-ringbuf_memcpy_from(void *dst, ringbuf_t src, size_t count);
+
+void *ringbufMemcpyFrom(void *dst, ringbuf_t src, size_t count);
 
 /*
  * This convenience function calls write(2) on the file descriptor fd,
@@ -230,8 +221,7 @@ ringbuf_memcpy_from(void *dst, ringbuf_t src, size_t count);
  * no bytes are written to the file descriptor, and the function will
  * return 0.
  */
-ssize_t
-ringbuf_write(int fd, ringbuf_t rb, size_t count);
+ssize_t ringbufWrite(int fd, ringbuf_t rb, size_t count);
 
 /*
  * Copy count bytes from ring buffer src, starting from its tail
@@ -256,15 +246,14 @@ ringbuf_write(int fd, ringbuf_t rb, size_t count);
  * number of bytes used in src, no bytes are copied, and the function
  * returns 0.
  */
-void *
-ringbuf_copy(ringbuf_t dst, ringbuf_t src, size_t count);
+void *ringbufCopy(ringbuf_t dst, ringbuf_t src, size_t count);
 
 //additions taken from fork of zipper97412/c-ringbuf
 
 /*poke some data from buffer src into ringbuffer*/
-int ringbuf_memwrite(ringbuf_t rb, size_t* src, size_t offset, size_t len);
+int ringbufMemwrite(ringbuf_t rb, size_t* src, size_t offset, size_t len);
 /*peek some data from ringbuffer into buffer dst */
-int ringbuf_memread(ringbuf_t rb, size_t* dst, size_t offset, size_t len);
+int ringbufMemread(ringbuf_t rb, size_t* dst, size_t offset, size_t len);
 
 
 #endif /* INCLUDED_RINGBUF_H */

--- a/ringbuf.h
+++ b/ringbuf.h
@@ -51,7 +51,10 @@ ringbuf_new(size_t capacity);
  * ringbuf_capacity function.
  */
  
-/*
+ 
+ /*
+* @brief Bind existing memory to a ringbuffer structure and make it a ringbuffer.
+*
 * This is to bind an existing memory area to a ringbuffer struct for management.
 * This is intended for microcontrollers w/o malloc and with the need for well controlled
 * memory management as the memory is assigned at linking time so we have enough or a linking error.
@@ -59,6 +62,10 @@ ringbuf_new(size_t capacity);
 * areas. So dirty coding can use a dma finished callback and call this routine to bind a ring buffer
 * to the transferred half of the dma memory area but beware of the buffer pointers and threads,
 * know what you code.  
+* @note: This bind assumes that the memory buffer is empty so the pointers are set up to show
+* an empty ring buffer. If you do dirty hacks here, set the pointers for your self after binding
+* the ringbuffer as you should know where the buffer ends and where useful data starts. Just
+* bend ->head and -> tail accordingly. 
 */
 ringbuf_t ringbuf_bind(ringbuf_t ringbuffer, uint8_t *buffer_address);
  

--- a/ringbuf.h
+++ b/ringbuf.h
@@ -50,6 +50,18 @@ ringbuf_new(size_t capacity);
  * For the usable capacity of the ring buffer, use the
  * ringbuf_capacity function.
  */
+ 
+/*
+* This is to bind an existing memory area to a ringbuffer struct for management.
+* This is intended for microcontrollers w/o malloc and with the need for well controlled
+* memory management as the memory is assigned at linking time so we have enough or a linking error.
+* One can expoit this to create a ringbuffer at existing memory buffers, for example dma memory
+* areas. So dirty coding can use a dma finished callback and call this routine to bind a ring buffer
+* to the transferred half of the dma memory area but beware of the buffer pointers and threads,
+* know what you code.  
+*/
+ringbuf_t ringbuf_bind(ringbuf_t ringbuffer, uint8_t *buffer_address);
+ 
 size_t
 ringbuf_buffer_size(const struct ringbuf_t *rb);
 
@@ -239,5 +251,13 @@ ringbuf_write(int fd, ringbuf_t rb, size_t count);
  */
 void *
 ringbuf_copy(ringbuf_t dst, ringbuf_t src, size_t count);
+
+//additions taken from fork of zipper97412/c-ringbuf
+
+/*poke some data from buffer src into ringbuffer*/
+int ringbuf_memwrite(ringbuf_t rb, size_t* src, size_t offset, size_t len);
+/*peek some data from ringbuffer into buffer dst */
+int ringbuf_memread(ringbuf_t rb, size_t* dst, size_t offset, size_t len);
+
 
 #endif /* INCLUDED_RINGBUF_H */


### PR DESCRIPTION
added bind_ringbuffer for embedded systems with static memory where there is no malloc, so a ring buffer can be bound to existing memory blocks, e.g. arrays.
Also I added good stuff of other forks, So this code would be a good starting point for further development.
