### PR TITLE
Add missing header. Fix implicit cast warnings. Add missing macro.

### DIFF
--- a/ringbuf.c
+++ b/ringbuf.c
@@ -162,7 +162,7 @@ ringbuf_findchr(const struct ringbuf_t *rb, int c, size_t offset)
     const uint8_t *start = rb->buf +
         (((rb->tail - rb->buf) + offset) % ringbuf_buffer_size(rb));
     assert(bufend > start);
-    size_t n = MIN(bufend - start, bytes_used - offset);
+    size_t n = MIN(bufend - start, (int)(bytes_used - offset));
     const uint8_t *found = memchr(start, c, n);
     if (found)
         return offset + (found - start);
@@ -182,7 +182,7 @@ ringbuf_memset(ringbuf_t dst, int c, size_t len)
 
         /* don't copy beyond the end of the buffer */
         assert(bufend > dst->head);
-        size_t n = MIN(bufend - dst->head, count - nwritten);
+        size_t n = MIN(bufend - dst->head, (int)(count - nwritten));
         memset(dst->head, c, n);
         dst->head += n;
         nwritten += n;
@@ -211,7 +211,7 @@ ringbuf_memcpy_into(ringbuf_t dst, const void *src, size_t count)
     while (nread != count) {
         /* don't copy beyond the end of the buffer */
         assert(bufend > dst->head);
-        size_t n = MIN(bufend - dst->head, count - nread);
+        size_t n = MIN(bufend - dst->head, (int)(count - nread));
         memcpy(dst->head, u8src + nread, n);
         dst->head += n;
         nread += n;
@@ -237,7 +237,7 @@ ringbuf_read(int fd, ringbuf_t rb, size_t count)
 
     /* don't write beyond the end of the buffer */
     assert(bufend > rb->head);
-    count = MIN(bufend - rb->head, count);
+    count = MIN(bufend - rb->head, (int)count);
     ssize_t n = read(fd, rb->head, count);
     if (n > 0) {
         assert(rb->head + n <= bufend);
@@ -248,7 +248,7 @@ ringbuf_read(int fd, ringbuf_t rb, size_t count)
             rb->head = rb->buf;
 
         /* fix up the tail pointer if an overflow occurred */
-        if (n > nfree) {
+        if (n > (int)nfree) {
             rb->tail = ringbuf_nextp(rb, rb->head);
             assert(ringbuf_is_full(rb));
         }
@@ -269,7 +269,7 @@ ringbuf_memcpy_from(void *dst, ringbuf_t src, size_t count)
     size_t nwritten = 0;
     while (nwritten != count) {
         assert(bufend > src->tail);
-        size_t n = MIN(bufend - src->tail, count - nwritten);
+        size_t n = MIN(bufend - src->tail, (int)(count - nwritten));
         memcpy(u8dst + nwritten, src->tail, n);
         src->tail += n;
         nwritten += n;
@@ -292,7 +292,7 @@ ringbuf_write(int fd, ringbuf_t rb, size_t count)
 
     const uint8_t *bufend = ringbuf_end(rb);
     assert(bufend > rb->head);
-    count = MIN(bufend - rb->tail, count);
+    count = MIN(bufend - rb->tail, (int)count);
     ssize_t n = write(fd, rb->tail, count);
     if (n > 0) {
         assert(rb->tail + n <= bufend);
@@ -321,9 +321,9 @@ ringbuf_copy(ringbuf_t dst, ringbuf_t src, size_t count)
     size_t ncopied = 0;
     while (ncopied != count) {
         assert(src_bufend > src->tail);
-        size_t nsrc = MIN(src_bufend - src->tail, count - ncopied);
+        size_t nsrc = MIN(src_bufend - src->tail, (int)(count - ncopied));
         assert(dst_bufend > dst->head);
-        size_t n = MIN(dst_bufend - dst->head, nsrc);
+        size_t n = MIN(dst_bufend - dst->head, (int)nsrc);
         memcpy(dst->head, src->tail, n);
         src->tail += n;
         dst->head += n;

--- a/ringbuf.c
+++ b/ringbuf.c
@@ -18,6 +18,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <assert.h>
 

--- a/ringbuf.c
+++ b/ringbuf.c
@@ -21,6 +21,10 @@
 #include <sys/types.h>
 #include <assert.h>
 
+#ifndef MIN
+#define MIN(x,y) ((x)>(y)?(y):(x))
+#endif
+
 /*
  * The code is written for clarity, not cleverness or performance, and
  * contains many assert()s to enforce invariant assumptions and catch

--- a/ringbuf.c
+++ b/ringbuf.c
@@ -19,8 +19,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
-#include <unistd.h>
-#include <sys/param.h>
 #include <assert.h>
 
 /*

--- a/ringbuf.h
+++ b/ringbuf.h
@@ -28,6 +28,9 @@
 
 #include <stddef.h>
 #include <sys/types.h>
+#ifdef _MSC_VER
+	typedef ptrdiff_t ssize_t;
+#endif
 
 typedef struct ringbuf_t *ringbuf_t;
 


### PR DESCRIPTION
This PR includes the following:

- Define MIN macro if undefined
- Add missing headers
- Add explicit casts to int, fixing implicit cast warnings with certain compiler settings