### PR TITLE
Typedef ptrdiff_t to ssize_t under Visual Studio. Fixes #15

### DIFF
--- a/ringbuf.h
+++ b/ringbuf.h
@@ -28,6 +28,9 @@
 
 #include <stddef.h>
 #include <sys/types.h>
+#ifdef _MSC_VER
+	typedef ptrdiff_t ssize_t;
+#endif
 
 typedef struct ringbuf_t *ringbuf_t;
 


### PR DESCRIPTION
ssize_t is a POSIX extension and therefore not available under Visual Studio.

This change defines ptrdiff_t as ssize_t, which is a compatible typedef since ptrdiff_t should always be at least as big as ssize_t

By submitting this PR, you agree to the following:

- [x] This contribution is dedicated to the public domain per the [COPYING](https://github.com/dhess/c-ringbuf/blob/master/COPYING) file included in this distribution. I am waiving any copyright claims with respect to this contribution, and I assert that this contribution is my own creation, and not taken from another work.
