### PR TITLE
Redefine the memory allocation function to solve the problem that the…

### DIFF
--- a/ringbuf.c
+++ b/ringbuf.c
@@ -26,7 +26,7 @@
 /*
  * The code is written for clarity, not cleverness or performance, and
  * contains many assert()s to enforce invariant assumptions and catch
- * bugs. Feel free to optimize the code and to remove asserts for use
+ * bugs. Feel rb_free to optimize the code and to remove asserts for use
  * in your own projects, once you're comfortable that it functions as
  * intended.
  */
@@ -41,16 +41,16 @@ struct ringbuf_t
 ringbuf_t
 ringbuf_new(size_t capacity)
 {
-    ringbuf_t rb = malloc(sizeof(struct ringbuf_t));
+    ringbuf_t rb = rb_malloc(sizeof(struct ringbuf_t));
     if (rb) {
 
         /* One byte is used for detecting the full condition. */
         rb->size = capacity + 1;
-        rb->buf = malloc(rb->size);
+        rb->buf = rb_malloc(rb->size);
         if (rb->buf)
             ringbuf_reset(rb);
         else {
-            free(rb);
+            rb_free(rb);
             return 0;
         }
     }
@@ -73,8 +73,8 @@ void
 ringbuf_free(ringbuf_t *rb)
 {
     assert(rb && *rb);
-    free((*rb)->buf);
-    free(*rb);
+    rb_free((*rb)->buf);
+    rb_free(*rb);
     *rb = 0;
 }
 

--- a/ringbuf.h
+++ b/ringbuf.h
@@ -31,6 +31,22 @@
 
 typedef struct ringbuf_t *ringbuf_t;
 
+
+/* 
+* The default rb_malloc, rb_free points to malloc 
+* and free functions, you can redefine these two functions
+* before, for example, in FreeRTOS, you can use #define 
+* rb_malloc pvPortMalloc to use the RTOS heap memory 
+* allocation API
+*/
+#ifndef rb_malloc 
+#define rb_malloc malloc
+#endif 
+
+#ifndef rb_free 
+#define rb_free free
+#endif
+
 /*
  * Create a new ring buffer with the given capacity (usable
  * bytes). Note that the actual internal buffer size may be one or


### PR DESCRIPTION
… microcontroller platform does not have the malloc function

# BEFORE MAKING A PULL REQUEST

Please read the [pull request guidelines](https://github.com/dhess/c-ringbuf/blob/master/.github/CONTRIBUTING.md#pull-requests)

**Before submitting this PR, please delete everything from this line and above, and check the boxes in the template below.**

--------------------------------------------------

By submitting this PR, you agree to the following:

- [ ] This contribution is dedicated to the public domain per the [COPYING](https://github.com/dhess/c-ringbuf/blob/master/COPYING) file included in this distribution. I am waiving any copyright claims with respect to this contribution, and I assert that this contribution is my own creation, and not taken from another work.
